### PR TITLE
Handle colons in password for URL config

### DIFF
--- a/src/valkyrie.gleam
+++ b/src/valkyrie.gleam
@@ -202,14 +202,12 @@ pub fn url_config(url: String) -> Result(Config, UrlParseError) {
 
   // Extract authentication from userinfo
   let auth = case parsed_uri.userinfo {
+    option.Some("") -> NoAuth
     option.Some(userinfo) -> {
-      case string.split(userinfo, ":") {
-        ["", password] -> PasswordOnly(password)
-        [username, password] -> UsernameAndPassword(username, password)
-        [password] -> PasswordOnly(password)
-        [] -> NoAuth
-        _ -> NoAuth
-        // fallback for malformed userinfo
+      case string.split_once(userinfo, ":") {
+        Ok(#("", password)) -> PasswordOnly(password)
+        Ok(#(username, password)) -> UsernameAndPassword(username, password)
+        Error(Nil) -> PasswordOnly(userinfo)
       }
     }
     option.None -> NoAuth

--- a/test/valkyrie_test.gleam
+++ b/test/valkyrie_test.gleam
@@ -121,6 +121,18 @@ pub fn url_config_with_auth_test() {
   config2.auth |> should.equal(valkyrie.UsernameAndPassword("user", "pass"))
 }
 
+pub fn url_config_with_auth_colon_in_password_test() {
+  // Password only with colons
+  let assert Ok(config1) = valkyrie.url_config("redis://:p:a:ss@localhost:6379")
+  config1.auth |> should.equal(valkyrie.PasswordOnly("p:a:ss"))
+
+  // Username and password with colons in password
+  let assert Ok(config2) =
+    valkyrie.url_config("redis://user:p:a:ss@localhost:6379")
+  config2.auth
+  |> should.equal(valkyrie.UsernameAndPassword("user", "p:a:ss"))
+}
+
 pub fn url_config_error_cases_test() {
   let assert Error(valkyrie.UnsupportedScheme) =
     valkyrie.url_config("http://localhost:6379")


### PR DESCRIPTION
Using split causes passwords with colons to be ignored entirely because it treats them as a list with more than two elements, and the connection falls back to NoAuth.